### PR TITLE
[Feature] Xg Mobile Detection

### DIFF
--- a/acControl/Scripts/ASUS_WMI.cs
+++ b/acControl/Scripts/ASUS_WMI.cs
@@ -25,6 +25,7 @@ public class ASUSWmi
     public const uint GPUEco = 0x00090020;
     public const uint GPUMux = 0x00090016;
     public const uint eGPU = 0x00090019;
+    public const uint eGPUConnected = 0x00090018;
 
     public const uint BatteryLimit = 0x00120057;
     public const uint ScreenOverdrive = 0x00050019;

--- a/acControl/Scripts/ToastNotification.cs
+++ b/acControl/Scripts/ToastNotification.cs
@@ -9,11 +9,11 @@ namespace acControl.Scripts
 {
     class ToastNotification
     {
-        public static void ShowToastNotification(bool isXg = false, string title = "", string body ="")
+        public static void ShowToastNotification(bool isXg = false, string title = "", string body = "")
         {
             string iconUri = "";
             string icon2Uri = "";
-            iconUri = "file:///" + App.location +"Assets\\applicationIcon.png";
+            iconUri = "file:///" + App.location + "Assets\\applicationIcon.png";
             icon2Uri = "file:///" + App.location + "Images\\XGMobile\\XGMobile-1.png";
 
             if (isXg)
@@ -33,6 +33,37 @@ namespace acControl.Scripts
                     .AddAppLogoOverride(new Uri(iconUri))
                     .Show();
             }
+        }
+
+        public static void PromptXgMobileActivate()
+        {
+            new ToastContentBuilder()
+                  .AddArgument("XgMobileOpen")
+                  .AddText("XG Mobile detected!")
+                  .AddAppLogoOverride(new Uri("file:///" + App.location + "Assets\\applicationIcon.png"))
+                  .AddInlineImage(new Uri("file:///" + App.location + "Images\\XGMobile\\XGMobile-1.png"))
+                  .AddButton(new ToastButton().SetContent("Activate")
+                  .AddArgument("XgMobileActivate"))
+                  .Show(toast => {
+                      toast.Tag = "AcXgMobile";
+                  });
+
+        }
+
+        public static bool IsActivateXgMobileToastButtonClicked(ToastNotificationActivatedEventArgsCompat toastArgs)
+        {
+            return toastArgs.Argument.Split(";", StringSplitOptions.RemoveEmptyEntries).Any((value) => "XgMobileActivate".Equals(value));
+        }
+
+        public static bool IsOpenXgMobileToastClicked(ToastNotificationActivatedEventArgsCompat toastArgs)
+        {
+            return toastArgs.Argument.Split(";", StringSplitOptions.RemoveEmptyEntries).Any((value) => "XgMobileOpen".Equals(value));
+        }
+
+        public static void HideXgMobileActivateToasts()
+        {
+            ToastNotificationManagerCompat.History.Remove("AcXgMobile");
+
         }
     }
 }

--- a/acControl/Services/XgMobileConnectionService.cs
+++ b/acControl/Services/XgMobileConnectionService.cs
@@ -1,0 +1,68 @@
+﻿using System;
+
+namespace acControl.Services
+{
+    public class XgMobileConnectionService
+    {
+        private readonly ASUSWmi wmi;
+
+        public bool Connected { get; private set; }
+        public bool Detected { get; private set; }
+
+        public class XgMobileStatusEvent
+        {
+            public bool Connected { get; init; }
+            public bool Detected { get; init; }
+            public bool DetectedChanged { get; init; }
+            public bool ConnectedChanged { get; init; }
+        }
+        public event EventHandler<XgMobileStatusEvent>? XgMobileStatus;
+
+        public XgMobileConnectionService(ASUSWmi wmi)
+        {
+            this.wmi = wmi;
+            UpdateXgMobileStatus();
+            wmi.SubscribeToEvents((a, b) => UpdateXgMobileStatus());
+        }
+
+        private void UpdateXgMobileStatus()
+        {
+            bool prevDetected = Detected;
+            bool prevConnected = Connected;
+            Detected = IsEGPUDetected();
+            if (Detected)
+            {
+                Connected = IsEGPUConnected();
+            }
+            else
+            {
+                Connected = false;
+            }
+            if (prevDetected != Detected || prevConnected != Connected)
+            {
+                XgMobileStatus?.Invoke(this, new XgMobileStatusEvent
+                {
+                    Detected = Detected,
+                    Connected = Connected,
+                    DetectedChanged = prevDetected != Detected,
+                    ConnectedChanged = prevConnected != Connected
+                });
+            }
+        }
+
+        private bool IsEGPUDetected()
+        {
+            return wmi.DeviceGet(ASUSWmi.eGPUConnected) == 1;
+        }
+
+        private bool IsEGPUConnected()
+        {
+            int deviceStatus = wmi.DeviceGet(ASUSWmi.eGPU);
+            if (deviceStatus != 0 && deviceStatus != 1)
+            {
+                throw new InvalidOperationException($"Unknown device status: {deviceStatus}");
+            }
+            return wmi.DeviceGet(ASUSWmi.eGPU) == 1;
+        }
+    }
+}


### PR DESCRIPTION
- Add Xg Mobile Detection in app
- Add toast message with button on detection
- Hide Xg mobile button on dashboard dynamically
- Fix Flow x13 2021 Mux switch check

PLEASE, CHECK FOR FALSY DETECTION, I MAY BE WRONG WITH XG MOBILE ID

The following scenarios need to be tested:

1. Detection on non-Flow devices should be disabled (no Xg mobile button, no toasts)
2. Toast should appear/disappear only on toggle of XG mobile (physical button on connector). I hope the setting I'm checking is not smth like lighting or anything but Xg mobile.
3. Please, check new MUX Switch detection on DashboardPage. I tried not to break existing logic, but I don't have any device with MUX, so I can only test the case when it's negative (not supported). 

BTW, it works on my device :)

