### PR TITLE
Alter tray icon to allow toggling window state

### DIFF
--- a/acControl/Views/Windows/MainWindow.xaml
+++ b/acControl/Views/Windows/MainWindow.xaml
@@ -77,7 +77,8 @@
             UseSnapLayout="True" Name="tbMain">
             <ui:TitleBar.Tray>
                 <ui:NotifyIcon
-                    FocusOnLeftClick="True"
+                    LeftClick="NotifyIcon_LeftClick"
+                    FocusOnLeftClick="False"
                     Icon="pack://application:,,,/Assets/applicationIcon-256.png"
                     MenuOnRightClick="True"
                     TooltipText="Armoury Control">

--- a/acControl/Views/Windows/MainWindow.xaml.cs
+++ b/acControl/Views/Windows/MainWindow.xaml.cs
@@ -219,5 +219,17 @@ namespace acControl.Views.Windows
             if (this.WindowState == WindowState.Minimized) this.WindowState = WindowState.Normal;
             _navigationService.Navigate(typeof(Views.Pages.CustomPresets));
         }
+
+        private void NotifyIcon_LeftClick(Wpf.Ui.Controls.NotifyIcon sender, RoutedEventArgs e)
+        {
+            if (this.WindowState != WindowState.Minimized)
+            {
+                this.WindowState = WindowState.Minimized;
+            } else
+            {
+                this.WindowState = WindowState.Normal;
+                this.Activate();
+            }
+        }
     }
 }


### PR DESCRIPTION
Alter tray icon definition to introduce a left click handler & vary behaviour based on whether the current window is restored or not.